### PR TITLE
fix local import error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.10
-RUN go get github.com/cavaliercoder/spodermen || :
+RUN go get github.com/cavaliercoder/spodermen
 WORKDIR /go/src/github.com/cavaliercoder/spodermen
 RUN go build -o spodermen main.go
 ENV PATH="$PATH:."

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 	"runtime"
 	"time"
 
-	"./crawler"
+	"github.com/cavaliercoder/spodermen/crawler"
 	"gopkg.in/urfave/cli.v1"
 )
 


### PR DESCRIPTION
Currently, `go get github.com/cavaliercoder/spodermen` fails with the following error:

```
src/github.com/cavaliercoder/spodermen/main.go:15:2: local import "./crawler" in non-local package
```

This is because `go get` does not allow local imports.